### PR TITLE
fix: scraper workflow npm cache path

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
+          cache-dependency-path: ./scraper/package-lock.json
       - run: npm install
         working-directory: ./scraper
       - run: npm run scrape

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -39,6 +39,7 @@ async function scrape() {
             await new Promise(resolve => setTimeout(resolve, 1000));
 
             downloadButton.click();
+            // TODO: listen download finished instead of delay
             await new Promise(resolve => setTimeout(resolve, 5000));
         }
     });


### PR DESCRIPTION
- fix scraper workflow npm cache path
- fix ts-node to dev script