### PR TITLE
chore: fix git add symbolic link doesn't work

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -37,7 +37,7 @@ jobs:
           git config --local user.email "ratchagitja@users.noreply.github.com"
           git config --local user.name "ratchagitja"
           git add ./data/ratchakitcha*.csv
-          git add ./entries/**/*.md
+          git add ./web/src/content/ratchagitja/**/*.md
           if ! git diff-index --quiet HEAD ./data/ratchakitcha*.csv; then
             git commit -m "docs: auto update ratchakitcha"
             git push


### PR DESCRIPTION
just changing the path is the easiest way.